### PR TITLE
New Feature: Add to Posts

### DIFF
--- a/Default_ko_fi_options.php
+++ b/Default_ko_fi_options.php
@@ -16,7 +16,7 @@ class Default_ko_fi_options {
 				'coffee_text'       => __( 'Buy me a coffee!', 'Ko_fi' ),
 				'coffee_color'      => __('46b798', 'Ko_fi' ),
                 'coffee_description'=> __( 'Buy me a coffee!', 'Ko_fi' ),
-				'coffee_code'       => 'KOFICODE or DISPLAYNAME',
+				'coffee_code'       => 'KOFICODE or USERNAME',
                 'coffee_hyperlink'  => false
 			),
 			'sections'           => array(
@@ -55,7 +55,7 @@ class Default_ko_fi_options {
 							'slug'        => 'code',
 							'title'       => __( 'Default Code', 'Ko_fi' ),
 							'type'        => 'text',
-							'description' => __( 'Your Ko-fi code or display name.', 'Ko_fi' ),
+							'description' => __( 'Your Ko-fi code or username.', 'Ko_fi' ),
 						),
                         array(
                             'slug'        => 'hyperlink',

--- a/Default_ko_fi_options.php
+++ b/Default_ko_fi_options.php
@@ -16,7 +16,7 @@ class Default_ko_fi_options {
 				'coffee_text'       => __( 'Buy me a coffee!', 'Ko_fi' ),
 				'coffee_color'      => __('46b798', 'Ko_fi' ),
                 'coffee_description'=> __( 'Buy me a coffee!', 'Ko_fi' ),
-				'coffee_code'       => 'http://ko-fi.com/',
+				'coffee_code'       => 'KOFICODE or DISPLAYNAME',
                 'coffee_hyperlink'  => false
 			),
 			'sections'           => array(
@@ -55,7 +55,7 @@ class Default_ko_fi_options {
 							'slug'        => 'code',
 							'title'       => __( 'Default Code', 'Ko_fi' ),
 							'type'        => 'text',
-							'description' => __( 'Your Ko-fi code or link.', 'Ko_fi' ),
+							'description' => __( 'Your Ko-fi code or display name.', 'Ko_fi' ),
 						),
                         array(
                             'slug'        => 'hyperlink',

--- a/Default_ko_fi_options.php
+++ b/Default_ko_fi_options.php
@@ -4,9 +4,9 @@ class Default_ko_fi_options {
 
 	public static function get(){
 		return array(
-			'page_title'        => __( 'ko-fi Settings', 'Ko_fi' ),
+			'page_title'        => __( 'Ko-fi Settings', 'Ko_fi' ),
 			'page_description'  => false,
-			'menu_title'        => __( 'ko-fi Settings', 'Ko_fi' ),
+			'menu_title'        => __( 'Ko-fi Settings', 'Ko_fi' ),
 			'capability'        => 'manage_options',
 			'menu_slug'         => 'ko_fi_options',
 			'option_name'       => 'ko_fi_options',
@@ -28,7 +28,7 @@ class Default_ko_fi_options {
 							'slug'        => 'title',
 							'title'       => __( 'Default Title', 'Ko_fi' ),
 							'type'        => 'text',
-                            'description' => __( 'Default title for your ko-fi widgets. The title will only display above the widgets, not the shortcode link.', 'Ko_fi' ),
+                            'description' => __( 'Default title for your Ko-fi widgets. The title will only display above the widgets, not the shortcode link.', 'Ko_fi' ),
                             'label'       => __( 'Test label', 'Ko_fi' )
 						),
 						array(
@@ -55,7 +55,7 @@ class Default_ko_fi_options {
 							'slug'        => 'code',
 							'title'       => __( 'Default Code', 'Ko_fi' ),
 							'type'        => 'text',
-							'description' => __( 'Your ko-fi code or link.', 'Ko_fi' ),
+							'description' => __( 'Your Ko-fi code or link.', 'Ko_fi' ),
 						),
                         array(
                             'slug'        => 'hyperlink',
@@ -63,6 +63,13 @@ class Default_ko_fi_options {
                             'type'        => 'checkbox',
                             'label'       => 'Hyperlink',
                             'description' => __( 'Check this box if you want to display your button as a hyperlink by default.', 'Ko_fi' ),
+						),
+                        array(
+                            'slug'        => 'posts',
+                            'title'       => __( 'Add to Posts', 'Ko_fi' ),
+                            'type'        => 'checkbox',
+                            'label'       => 'Posts',
+                            'description' => __( 'Check this box if you want add a pretty linkbox to the bottom of all your posts.', 'Ko_fi' ),
                         )
 					)
 				)

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -28,8 +28,6 @@ class Ko_Fi
         self::$options = (new Ko_fi_Options())->get();
         add_filter('plugin_action_links', [__CLASS__,'add_action_links'],10,5);
         add_filter('the_content', [__CLASS__, 'add_to_posts'], 10, 5);
-
-        wp_enqueue_style( 'ko-fi', plugin_dir_url( __FILE__ ) . 'ko-fi-styles.css' );
     }
 
     public static function add_action_links($actions, $plugin_file)

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -164,22 +164,22 @@ class Ko_Fi
             $button_html = self::build_button(self::$options);
                 
             $linkbox = <<<EOT
-    <div class="ko-fi-box">
-      <div>
-        <h3 style="text-align: center;">
-            {$title}
-        </h3>
-      </div>
-      <div>
-        <p style="text-align: center;">
-          {$description}
-        </p>
-      </div>
-      <div class="ko-fi-button"> 
-          {$button_html}
-      </div>
-    </div>
-    EOT;
+<div class="ko-fi-box">
+  <div>
+    <h3 style="text-align: center;">
+        {$title}
+    </h3>
+  </div>
+  <div>
+    <p style="text-align: center;">
+      {$description}
+    </p>
+  </div>
+  <div class="ko-fi-button"> 
+      {$button_html}
+  </div>
+</div>
+EOT;
             $theContent = $content;
             return (is_single()) ? $theContent . $linkbox : $theContent;
 

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -47,7 +47,6 @@ class Ko_Fi
 
             $actions = array_merge($plugin_links, $actions);
 
-
         }
 
         return $actions;

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -189,7 +189,6 @@ EOT;
 }
 
 function add_kofi_styles() {
-    //wp_enqueue_style( 'ko-fi', plugin_dir_url( __FILE__ ) . 'ko-fi-styles.css' );
     wp_register_style('ko-fi', plugins_url('ko-fi-styles.css', __FILE__));
     wp_enqueue_style('ko-fi');
 }

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -13,6 +13,8 @@ License: GPL2
 class Ko_Fi
 {
 
+    const KOFI_URL = "https://www.ko-fi.com";
+
     public static $options = [];
 
     public static function init()
@@ -130,9 +132,9 @@ class Ko_Fi
             $settings[$key] = $value;
         }
         if ($settings['coffee_hyperlink'] === true) {
-            return "<a href='" . "http://www.ko-fi.com/" . $settings['coffee_code'] . "'>{$settings['coffee_text']}</a>";
+            return "<a href='" . self::KOFI_URL . "/" . $settings['coffee_code'] . "'>{$settings['coffee_text']}</a>";
         } else {
-            return "<script type='text/javascript' src='https://ko-fi.com/widgets/widget_2.js'></script>
+            return "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
 	        <script type='text/javascript'>kofiwidget2.init('" . $settings['coffee_text'] . "', '#" . $settings['coffee_color'] . "', '" . $settings['coffee_code'] . "');
 	            kofiwidget2.draw();</script>";
         }
@@ -151,6 +153,7 @@ class Ko_Fi
             $title = self::$options['coffee_title'];
             $description = self::$options['coffee_description'];
             $code = self::$options['coffee_code'];
+            $kofi_url = self::KOFI_URL;
             $linkbox = <<<EOT
     <div style="overflow:hidden;border-radius:5px 5px 5px 5px;box-shadow: 3px 2px 3px 5px;padding: 2% 2% 2% 2%; background-position:left top;background-repeat:no-repeat;-webkit-background-size:cover-moz-background-size:cover;-o-background-size:cover;background-size:cover;border-radius:5px 5px 5px 5px;"data-bg-url="">
     <div>
@@ -164,7 +167,7 @@ class Ko_Fi
         </p>
     </div>
     <div style="text-align: center; display: flex; justify-content: center;"> 
-        <a href="https://ko-fi.com/{$code}" target="_blank">
+        <a href="{$kofi_url}/{$code}" target="_blank">
             <img style="border:0px;height:45px;" src="https://az743702.vo.msecnd.net/cdn/kofi5.png?v=2" alt="Buy Me a Coffee at ko-fi.com" height="45" border="0" align="middle"></a>
         </div>
     </div>

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -154,23 +154,27 @@ class Ko_Fi
             $description = self::$options['coffee_description'];
             $code = self::$options['coffee_code'];
             $kofi_url = self::KOFI_URL;
+
+            // To do: refactor with get_embed_code snippet.
+            $button_code = "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
+	        <script type='text/javascript'>kofiwidget2.init('" . self::$options['coffee_text'] . "', '#" . self::$options['coffee_color'] . "', '" . self::$options['coffee_code'] . "');
+                kofiwidget2.draw();</script>";
+                
             $linkbox = <<<EOT
     <div style="overflow:hidden;border-radius:5px 5px 5px 5px;box-shadow: 3px 2px 3px 5px;padding: 2% 2% 2% 2%; background-position:left top;background-repeat:no-repeat;-webkit-background-size:cover-moz-background-size:cover;-o-background-size:cover;background-size:cover;border-radius:5px 5px 5px 5px;"data-bg-url="">
-    <div>
+      <div>
         <h3 style="text-align: center;">
             {$title}
         </h3>
-    </div>
-    <div>
+      </div>
+      <div>
         <p style="text-align: center;">
-            {$description}
+          {$description}
         </p>
-    </div>
-    <div style="text-align: center; display: flex; justify-content: center;"> 
-        <a href="{$kofi_url}/{$code}" target="_blank">
-            <img style="border:0px;height:45px;" src="https://az743702.vo.msecnd.net/cdn/kofi5.png?v=2" alt="Buy Me a Coffee at ko-fi.com" height="45" border="0" align="middle"></a>
-        </div>
-    </div>
+      </div>
+      <div style="text-align: center; display: flex; justify-content: center;"> 
+          {$button_code}
+      </div>
     </div>
     EOT;
             $theContent = $content;

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -131,6 +131,7 @@ class Ko_Fi
             }
             $settings[$key] = $value;
         }
+        // To do: Need to sanitise coffee text. 
         if ($settings['coffee_hyperlink'] === true) {
             return "<a href='" . self::KOFI_URL . "/" . $settings['coffee_code'] . "'>{$settings['coffee_text']}</a>";
         } else {
@@ -150,13 +151,15 @@ class Ko_Fi
             $doPosts = self::$options['coffee_posts'];
         }
         if ($doPosts) {
+
+            // To do: Need to sanitise button text.
             $title = self::$options['coffee_title'];
             $description = self::$options['coffee_description'];
             $code = self::$options['coffee_code'];
             $kofi_url = self::KOFI_URL;
 
             // To do: refactor with get_embed_code snippet.
-            $button_code = "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
+            $button_html = "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
 	        <script type='text/javascript'>kofiwidget2.init('" . self::$options['coffee_text'] . "', '#" . self::$options['coffee_color'] . "', '" . self::$options['coffee_code'] . "');
                 kofiwidget2.draw();</script>";
                 
@@ -173,7 +176,7 @@ class Ko_Fi
         </p>
       </div>
       <div style="text-align: center; display: flex; justify-content: center;"> 
-          {$button_code}
+          {$button_html}
       </div>
     </div>
     EOT;

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -102,6 +102,12 @@ class Ko_Fi
 
     }
 
+    public static function build_button($atts)
+    {
+        return "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
+        <script type='text/javascript'>kofiwidget2.init('" . esc_attr($atts['coffee_text']) . "', '#" . $atts['coffee_color'] . "', '" . $atts['coffee_code'] . "'); kofiwidget2.draw();</script>";
+    }
+
     public static function get_embed_code($atts)
     {
 
@@ -131,13 +137,10 @@ class Ko_Fi
             }
             $settings[$key] = $value;
         }
-        // To do: Need to sanitise coffee text. 
         if ($settings['coffee_hyperlink'] === true) {
-            return "<a href='" . self::KOFI_URL . "/" . $settings['coffee_code'] . "'>{$settings['coffee_text']}</a>";
+            return "<a href='" . self::KOFI_URL . "/" . $settings['coffee_code'] . "'>" . esc_attr($settings['coffee_text']) . "</a>";
         } else {
-            return "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
-	        <script type='text/javascript'>kofiwidget2.init('" . $settings['coffee_text'] . "', '#" . $settings['coffee_color'] . "', '" . $settings['coffee_code'] . "');
-	            kofiwidget2.draw();</script>";
+            return self::build_button($settings);
         }
     }
 
@@ -152,16 +155,12 @@ class Ko_Fi
         }
         if ($doPosts) {
 
-            // To do: Need to sanitise button text.
             $title = self::$options['coffee_title'];
             $description = self::$options['coffee_description'];
             $code = self::$options['coffee_code'];
             $kofi_url = self::KOFI_URL;
 
-            // To do: refactor with get_embed_code snippet.
-            $button_html = "<script type='text/javascript' src='" . self::KOFI_URL . "/widgets/widget_2.js'></script>
-	        <script type='text/javascript'>kofiwidget2.init('" . self::$options['coffee_text'] . "', '#" . self::$options['coffee_color'] . "', '" . self::$options['coffee_code'] . "');
-                kofiwidget2.draw();</script>";
+            $button_html = self::build_button(self::$options);
                 
             $linkbox = <<<EOT
     <div style="overflow:hidden;border-radius:5px 5px 5px 5px;box-shadow: 3px 2px 3px 5px;padding: 2% 2% 2% 2%; background-position:left top;background-repeat:no-repeat;-webkit-background-size:cover-moz-background-size:cover;-o-background-size:cover;background-size:cover;border-radius:5px 5px 5px 5px;"data-bg-url="">

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -25,6 +25,7 @@ class Ko_Fi
         require_once 'Ko_fi_Options.php';
         self::$options = (new Ko_fi_Options())->get();
         add_filter('plugin_action_links', [__CLASS__,'add_action_links'],10,5);
+        add_filter('the_content', [__CLASS__, 'add_to_posts'], 10, 5);
     }
 
     public static function add_action_links($actions, $plugin_file)
@@ -137,6 +138,45 @@ class Ko_Fi
         }
     }
 
+    /**
+     * Add the pretty linkbox to the bottom of all posts.
+     */
+    public static function add_to_posts($content)
+    {
+        $doPosts = false;
+        if (isset(self::$options['coffee_posts'])) {
+            $doPosts = self::$options['coffee_posts'];
+        }
+        if ($doPosts) {
+            $title = self::$options['coffee_title'];
+            $description = self::$options['coffee_description'];
+            $code = self::$options['coffee_code'];
+            $linkbox = <<<EOT
+    <div style="overflow:hidden;border-radius:5px 5px 5px 5px;box-shadow: 3px 2px 3px 5px;padding: 2% 2% 2% 2%; background-position:left top;background-repeat:no-repeat;-webkit-background-size:cover-moz-background-size:cover;-o-background-size:cover;background-size:cover;border-radius:5px 5px 5px 5px;"data-bg-url="">
+    <div>
+        <h3 style="text-align: center;">
+            {$title}
+        </h3>
+    </div>
+    <div>
+        <p style="text-align: center;">
+            {$description}
+        </p>
+    </div>
+    <div style="text-align: center; display: flex; justify-content: center;"> 
+        <a href="https://ko-fi.com/{$code}" target="_blank">
+            <img style="border:0px;height:45px;" src="https://az743702.vo.msecnd.net/cdn/kofi5.png?v=2" alt="Buy Me a Coffee at ko-fi.com" height="45" border="0" align="middle"></a>
+        </div>
+    </div>
+    </div>
+    EOT;
+            $theContent = $content;
+            return (is_single()) ? $theContent . $linkbox : $theContent;
+
+        } else {
+            return $content;
+        }
+    }
 
 }
 

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -190,4 +190,11 @@ EOT;
 
 }
 
+function add_kofi_styles() {
+    //wp_enqueue_style( 'ko-fi', plugin_dir_url( __FILE__ ) . 'ko-fi-styles.css' );
+    wp_register_style('ko-fi', plugins_url('ko-fi-styles.css', __FILE__));
+    wp_enqueue_style('ko-fi');
+}
+add_action ('wp_enqueue_scripts', 'add_kofi_styles');
+
 add_action('plugins_loaded', ['Ko_Fi', 'init']);

--- a/Ko_fi.php
+++ b/Ko_fi.php
@@ -28,6 +28,8 @@ class Ko_Fi
         self::$options = (new Ko_fi_Options())->get();
         add_filter('plugin_action_links', [__CLASS__,'add_action_links'],10,5);
         add_filter('the_content', [__CLASS__, 'add_to_posts'], 10, 5);
+
+        wp_enqueue_style( 'ko-fi', plugin_dir_url( __FILE__ ) . 'ko-fi-styles.css' );
     }
 
     public static function add_action_links($actions, $plugin_file)
@@ -163,7 +165,7 @@ class Ko_Fi
             $button_html = self::build_button(self::$options);
                 
             $linkbox = <<<EOT
-    <div style="overflow:hidden;border-radius:5px 5px 5px 5px;box-shadow: 3px 2px 3px 5px;padding: 2% 2% 2% 2%; background-position:left top;background-repeat:no-repeat;-webkit-background-size:cover-moz-background-size:cover;-o-background-size:cover;background-size:cover;border-radius:5px 5px 5px 5px;"data-bg-url="">
+    <div class="ko-fi-box">
       <div>
         <h3 style="text-align: center;">
             {$title}
@@ -174,7 +176,7 @@ class Ko_Fi
           {$description}
         </p>
       </div>
-      <div style="text-align: center; display: flex; justify-content: center;"> 
+      <div class="ko-fi-button"> 
           {$button_html}
       </div>
     </div>

--- a/ko-fi-styles.css
+++ b/ko-fi-styles.css
@@ -12,11 +12,11 @@
     overflow: hidden;
 }
 .ko-fi-box {
-    width: 767px;
+    max-width: 767px;
+    min-width: 300px;
     border-radius: 5px 5px 5px 5px;
     box-shadow: 3px 2px 3px 5px;
     padding: 2% 2% 2% 2%; 
-    border-radius:5px 5px 5px 5px;
     margin: 0 auto;
 }
 

--- a/ko-fi-styles.css
+++ b/ko-fi-styles.css
@@ -1,0 +1,27 @@
+/**
+ * Ko-fi Button Plugin Styles
+ */
+
+.ko-fi-box,
+.ko-fi-button {
+    text-align: center; 
+    display: flex; 
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+.ko-fi-box {
+    width: 767px;
+    border-radius: 5px 5px 5px 5px;
+    box-shadow: 3px 2px 3px 5px;
+    padding: 2% 2% 2% 2%; 
+    border-radius:5px 5px 5px 5px;
+    margin: 0 auto;
+}
+
+.ko-fi-box h2,
+.ko-fi-box h3,
+.ko-fi-box p {
+    text-align: center;
+}

--- a/ko_fi_widget.php
+++ b/ko_fi_widget.php
@@ -77,7 +77,7 @@ class ko_fi_widget extends WP_Widget
                       name="<?php echo $this->get_field_name('description'); ?>" rows="5"
                       type="text"><?php echo $description ?></textarea>
 
-			<label for="<?php echo $this->get_field_id('code'); ?>"><?php _e('Code:'); ?></label>
+			<label for="<?php echo $this->get_field_id('code'); ?>"><?php _e('Code or Username:'); ?></label>
             <input class="widefat" id="<?php echo $this->get_field_id('code'); ?>"
                    name="<?php echo $this->get_field_name('code'); ?>" type="text" value="<?php echo $code ?>">
 


### PR DESCRIPTION
## Enhancement

### Add to Posts

I created a new "Add to Posts" feature. When selected in the main Ko-fi Button plugin settings, a content box (prettified linkbox) will be generated and displayed at the bottom of every blog post. The linkbox will contain the values defined in the display settings (e.g. title, text, description, button URL, button colour).

I added a stylesheet file (ko-fi-styles.css) to help separate the styles from the PHP and HTML code for this feature.

### Motivation

I _manually_ add a linkbox to all my blog posts on my WordPress site running on the Avada theme. Using a custom global element. It would be great to automate this.

Here's what the manual version looks like. I.e., the *before* image.

<img width="1514" alt="marklchaves-ko-fi-linkbox" src="https://user-images.githubusercontent.com/4658423/71381459-363f5180-2606-11ea-850e-a1e61c77e750.png">

## Fixes

I added PHP code to _escape_ the button text. Before, the button would not display if special characters existed in the button text.

I removed the default placeholder for the Ko-fi code. It was the URL for the Ko-fi website. It was inaccurate and misleading since that field (value) will be appended to the Ko-fi website URL.

I cleaned up more inconsistencies with Ko-fi capitalisation in the HTML (public facing pages). They should be all "Ko-fi" now instead of ko-fi or Ko-Fi.

## Issues Found During Development

1. Widget code setting is **overridden** by main plugin code setting on public page, but still displays different widget code (if entered) in admin page. Meaning can have two different codes, but only the main setting will work.
2. **Hyperlink** settings doesn't seem to do anything--maybe setting is for the shortcode?

I'll create GitHub issues for these.

## Testing Details

### PHP Versions
- PHP Version 7.2.18
- PHP Version 7.3.2
- PHP Compatibility Checker 7.0 to 7.3
- Will test on PHP 7.4 shortly.

### WordPress
- WordPress 5.3.2 running Shapely theme.
- WordPress 5.3.2 running Twenty Twenty Child theme.

### Chrome
- Version 79.0.3945.79 (Official Build) (64-bit)

### Firefox
- 71.0 (64-bit)

### Safari
- Version 13.0.4 (14608.4.9.1.4)

### Edge
- Version 44.18362.449.0

### macOS
- Version 10.14.6 (18G1012)

### iOS
- 13.1.2

### Windows
- Windows 10 Pro Version 1903

### Devices
- MacBook Pro
- iPhone 6
- Surface 

## Screen Captures

<img width="797" alt="kofi-button-plugin-posts-astra" src="https://user-images.githubusercontent.com/4658423/71314474-f9e3e800-2483-11ea-8dc5-00baf880d9a0.png">

<img width="1321" alt="kofi-button-plugin-posts-avada" src="https://user-images.githubusercontent.com/4658423/71314481-2ef03a80-2484-11ea-90a9-e1b9d9f7a1cd.png">

<img width="1325" alt="kofi-button-plugin-posts-shapely" src="https://user-images.githubusercontent.com/4658423/71314482-2ef03a80-2484-11ea-9c49-785bb270460b.png">

<img width="375" alt="PNG image" src="https://user-images.githubusercontent.com/4658423/71381509-596a0100-2606-11ea-8107-883eb08e1aa4.png">

<img width="1109" alt="ko-fi-button-plugin-settings-add-to-post" src="https://user-images.githubusercontent.com/4658423/71314567-7a571880-2485-11ea-9d2e-7d6dc97f92df.png">
